### PR TITLE
#8  [update] Updated app name from 'translate_app' to 'Translator'

### DIFF
--- a/translate_app/README.md
+++ b/translate_app/README.md
@@ -1,4 +1,4 @@
-# translate_app
+# Translator
 
 A new Flutter project.
 

--- a/translate_app/android/app/src/main/AndroidManifest.xml
+++ b/translate_app/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
         <uses-permission android:name="android.permission.INTERNET"/>       
     <application
-        android:label="translate_app"
+        android:label="Translator"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/translate_app/ios/Runner/Info.plist
+++ b/translate_app/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Translate App</string>
+	<string>Translator</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>translate_app</string>
+	<string>Translator</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/translate_app/lib/main.dart
+++ b/translate_app/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:translate_app/models/language.dart';
-import 'package:translate_app/services/service.dart';
+import 'package:Translator/models/language.dart';
+import 'package:Translator/services/service.dart';
 // import 'package:get/get.dart';
 
 void main() {

--- a/translate_app/linux/CMakeLists.txt
+++ b/translate_app/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "translate_app")
+set(BINARY_NAME "Translator")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.translate_app")
+set(APPLICATION_ID "com.example.Translator")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/translate_app/linux/my_application.cc
+++ b/translate_app/linux/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "translate_app");
+    gtk_header_bar_set_title(header_bar, "Translator");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "translate_app");
+    gtk_window_set_title(window, "Translator");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/translate_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/translate_app/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* translate_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "translate_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* Translator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Translator.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* translate_app.app */,
+				33CC10ED2044A3C60003C045 /* Translator.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* translate_app.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* Translator.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -387,7 +387,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.translateApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/translate_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/translate_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Translator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Translator";
 			};
 			name = Debug;
 		};
@@ -401,7 +401,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.translateApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/translate_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/translate_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Translator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Translator";
 			};
 			name = Release;
 		};
@@ -415,7 +415,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.translateApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/translate_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/translate_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Translator.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Translator";
 			};
 			name = Profile;
 		};

--- a/translate_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/translate_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "translate_app.app"
+               BuildableName = "Translator.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "translate_app.app"
+            BuildableName = "Translator.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "translate_app.app"
+            BuildableName = "Translator.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -82,7 +82,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "translate_app.app"
+            BuildableName = "Translator.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/translate_app/macos/Runner/Configs/AppInfo.xcconfig
+++ b/translate_app/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = translate_app
+PRODUCT_NAME = Translator
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.example.translateApp

--- a/translate_app/pubspec.yaml
+++ b/translate_app/pubspec.yaml
@@ -1,4 +1,4 @@
-name: translate_app
+name: Translator
 description: A new Flutter project.
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.

--- a/translate_app/test/widget_test.dart
+++ b/translate_app/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:translate_app/main.dart';
+import 'package:Translator/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/translate_app/web/index.html
+++ b/translate_app/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="translate_app">
+  <meta name="apple-mobile-web-app-title" content="Translator">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>translate_app</title>
+  <title>Translator</title>
   <link rel="manifest" href="manifest.json">
 
   <script>

--- a/translate_app/windows/runner/Runner.rc
+++ b/translate_app/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "translate_app" "\0"
+            VALUE "FileDescription", "Translator" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "translate_app" "\0"
+            VALUE "InternalName", "Translator" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2023 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "translate_app.exe" "\0"
-            VALUE "ProductName", "translate_app" "\0"
+            VALUE "OriginalFilename", "Translator.exe" "\0"
+            VALUE "ProductName", "Translator" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/translate_app/windows/runner/main.cpp
+++ b/translate_app/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"translate_app", origin, size)) {
+  if (!window.Create(L"Translator", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
issue #8 
changed the app name from translate_app to Translator for android, ios,macOS, windows and linux.
updated the changes in ui.
updated references

