### PR TITLE
 Replaced Custom API with Deep translator api #3

### DIFF
--- a/translate_app/lib/services/service.dart
+++ b/translate_app/lib/services/service.dart
@@ -10,7 +10,9 @@ class Service {
     };
 
     final data =
-        '{\n  "source": "en",\n  "target": "es",\n  "text": "hello",\n  "proxies": []\n}';
+        '{\n  "source": "en",\n  "target": "${lang}",\n  "text": "${text}",\n  "proxies": []\n}';
+
+    print(data);
 
     final url =
         Uri.parse('https://deep-translator-api.azurewebsites.net/mymemory/');

--- a/translate_app/lib/services/service.dart
+++ b/translate_app/lib/services/service.dart
@@ -3,19 +3,43 @@ import 'dart:convert';
 
 class Service {
   Future<String> translateText(String text, String lang) async {
-    String url = "https://todoapp-7jzr.onrender.com/translate/translateLang";
-    final response = await http.post(Uri.parse(url),
-        body: {"text": text, "targetLang": lang, "sourceLang": "en"});
+    // String key = ""
+    final headers = {
+      'accept': 'application/json',
+      'Content-Type': 'application/json',
+    };
+
+    final data =
+        '{\n  "source": "en",\n  "target": "es",\n  "text": "hello",\n  "proxies": []\n}';
+
+    final url =
+        Uri.parse('https://deep-translator-api.azurewebsites.net/mymemory/');
+
+    final response = await http.post(url, headers: headers, body: data);
+    // String url =
+    //     "https://deep-translator-api.azurewebsites.net/mymemory/";
+    // final response = await http.post(Uri.parse(url), headers: {
+    //   'X-RapidAPI-Key': 'c31066519fmsh127a08d5258a9c3p1f3d85jsn61dd90156031',
+    //   'X-RapidAPI-Host': 'microsoft-translator-text.p.rapidapi.com'
+    // }, body: {
+    //   "source": "auto",
+    //   "target": lang,
+    //   "text": text,
+    // });
+    print("printing resposnse");
+    print(response.statusCode.toString());
     var result;
     if (response.statusCode == 200) {
       var answer = json.decode(response.body);
+      print("answer");
       print(answer);
-      if (answer['success'] == true) {
-        answer = answer['message']!['data']['translations'];
-        result = answer![0]['translatedText'].toString();
+      if (answer['error'] == null) {
+        answer = answer['translation'];
+        result = answer.toString();
       } else {
         result = "Something went wrong";
       }
+      print("result");
       print(result);
     } else {
       result = "Something went wrong";

--- a/translate_app/pubspec.lock
+++ b/translate_app/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -91,6 +91,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -103,34 +127,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -148,18 +172,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -180,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -200,13 +224,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"


### PR DESCRIPTION
 Replaced Custom API with Deep Translator API #3 
fixes: #3 
as mentioned by @Illuminati9 it is not mandatory to use Google API so i used Deep Translator API which is free to use and does not require any auth tokens.

1. Api used -> `https://deep-translator-api.azurewebsites.net/mymemory/`
2. screenshot of fixes (Test)
![chrome-capture-2024-3-17 (3)](https://github.com/iiitl/translate_app/assets/65962770/44551197-c4e4-481a-b7f3-2a6ec2c4231f)
3. no credentials or access tokens are required
4. As there are no changes that require any tokens or auth keys no need to add anything to documentation